### PR TITLE
Bump msp430 dependency to 0.2.0 and release new version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panic-msp430"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["YuhanLiin <linyuhan0315@hotmail.com>"]
 keywords = ["panic-handler", "panic", "msp430"]
 license = "MIT OR Apache-2.0"
@@ -11,4 +11,4 @@ documentation = "https://docs.rs/panic-msp430"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-msp430 = "0.1.0"
+msp430 = "0.2.0"


### PR DESCRIPTION
I was hoping to avoid this, but a major version of increase of the msp430 crate is [unavoidable](https://github.com/rust-embedded/msp430/pull/3). You can still use `0.1.0` just fine, but in code using `0.2.0` of other crates, using `panic_msp430 0.1.0` may bring in multiple versions of the same crate in the dependency graph.

This is probably actually fine as a bump to `0.1.1`, since this crate doesn't expose any part of `msp430` crate to the user. But I think I want a clean break between the old API and new...